### PR TITLE
Add prune option

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,13 +88,24 @@ module.exports = function packager (opts, cb) {
     // copy users app into .app
     ncp(opts.dir, paths.app, {filter: filter}, function copied (err) {
       if (err) return cb(err)
-      
-      // finally, move app into cwd
-      var finalPath = opts.out || process.cwd()
-      // TODO dont spawn, but I couldn't find a good module
-      child.exec('mv "' + newApp + '" "' + finalPath + '"', function moved (err) {
-        cb(err, path.join(finalPath, opts.name + '.app'))
-      })
+
+      function moveApp (err) {
+        if (err) return cb(err)
+
+        // finally, move app into cwd
+        var finalPath = opts.out || process.cwd()
+        // TODO dont spawn, but I couldn't find a good module
+        child.exec('mv "' + newApp + '" "' + finalPath + '"', function moved (err) {
+          cb(err, path.join(finalPath, opts.name + '.app'))
+        })
+      }
+
+      // run npm prune
+      if (opts.prune) {
+        child.exec('npm prune --production', { cwd: paths.app }, moveApp)
+      } else {
+        moveApp()
+      }
     })
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -36,3 +36,4 @@ these are optional CLI options you can pass in
 - `app-bundle-id` - bundle identifier to use in the app plist
 - `helper-bundle-id` - bundle identifier to use in the app helper plist
 - `ignore` (default none) - do not copy files into App whose filenames regex .match this string
+- `prune` - runs `npm prune --production` on the app


### PR DESCRIPTION
Fixes GH-4.

When run with `--prune`, it'll run on `npm prune --production` on the app folder. Leaves the original directory's modules in tact.